### PR TITLE
Optimize string rendering with document range frags

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,17 @@
-// Create a range object to efficently render strings to elements.
+// Create a range object for efficently rendering strings to elements.
 var range = document.createRange();
 range.selectNode(document.body);
+
+function toElement(str) {
+    var fragment;
+    if (range.createContextualFragment) {
+        fragment = range.createContextualFragment(str);
+    } else {
+        fragment = document.createElement('body');
+        fragment.innerHTML = str;
+    }
+    return fragment.childNodes[0];
+}
 
 var specialElHandlers = {
     /**
@@ -101,8 +112,7 @@ function morphdom(fromNode, toNode, options) {
     }
 
     if (typeof toNode === 'string') {
-        var fragment = range.createContextualFragment(toNode);
-        toNode = fragment.childNodes[0];
+        toNode = toElement(toNode);
     }
 
     var savedEls = {}; // Used to save off DOM elements with IDs

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,7 @@
+// Create a range object to efficently render strings to elements.
+var range = document.createRange();
+range.selectNode(document.body);
+
 var specialElHandlers = {
     /**
      * Needed for IE. Apparently IE doesn't think
@@ -97,9 +101,8 @@ function morphdom(fromNode, toNode, options) {
     }
 
     if (typeof toNode === 'string') {
-        var newBodyEl = document.createElement('body');
-        newBodyEl.innerHTML = toNode;
-        toNode = newBodyEl.childNodes[0];
+        var fragment = range.createContextualFragment(toNode);
+        toNode = fragment.childNodes[0];
     }
 
     var savedEls = {}; // Used to save off DOM elements with IDs


### PR DESCRIPTION
This avoids creating a new element at each step and instead renders the string to a document fragment. This method was shown to be the fastest way to convert string->element in the past (IE>=9)

https://developer.mozilla.org/en-US/docs/Web/API/Range/createContextualFragment