### PR TITLE
Add onBeforeNodeDiscarded callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Supported options (all optional):
 ```javascript
 var morphdom = require('morphdom');
 var morphedNode = morphdom(fromNode, toNode, {
-    onBeforeNodeDiscarded(node) {
+    onBeforeNodeDiscarded: function(node) {
         return true;
     }
     onNodeDiscarded: function(node) {

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The returned value will typically be the `fromNode`. However, in situations wher
 
 Supported options (all optional):
 
+- *onBeforeNodeDiscarded* (`Function(node)`) - A function that will called before a `Node` in the `from` tree has been discarded. If the listener function returns `false` then the element will not be discarded.
 - *onNodeDiscarded* (`Function(node)`) - A function that will called when a `Node` in the `from` tree has been discarded and will no longer exist in the final DOM tree.
 - *onBeforeMorphEl* (`Function(fromEl, toEl)`) - A function that will called when a `HTMLElement` in the `from` tree is about to be morphed. If the listener function returns `false` then the element will be skipped.
 - *onBeforeMorphElChildren* (`Function(fromEl, toEl)`) - A function that will called when the children of an `HTMLElement` in the `from` tree are about to be morphed. If the listener function returns `false` then the child nodes will be skipped.
@@ -73,6 +74,9 @@ Supported options (all optional):
 ```javascript
 var morphdom = require('morphdom');
 var morphedNode = morphdom(fromNode, toNode, {
+    onBeforeNodeDiscarded(node) {
+        return true;
+    }
     onNodeDiscarded: function(node) {
 
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -124,6 +124,7 @@ function morphdom(fromNode, toNode, options) {
     var onNodeDiscarded = options.onNodeDiscarded || noop;
     var onBeforeMorphEl = options.onBeforeMorphEl || noop;
     var onBeforeMorphElChildren = options.onBeforeMorphElChildren || noop;
+    var onBeforeNodeDiscarded = options.onBeforeNodeDiscarded || noop;
 
     function removeNodeHelper(node, nestedInSavedEl) {
         var id = node.id;
@@ -169,8 +170,11 @@ function morphdom(fromNode, toNode, options) {
     }
 
     function removeNode(node, parentNode, alreadyVisited) {
-        parentNode.removeChild(node);
+        if (onBeforeNodeDiscarded(node) === false) {
+            return;
+        }
 
+        parentNode.removeChild(node);
         if (alreadyVisited) {
             if (!node.id) {
                 onNodeDiscarded(node);

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -368,6 +368,31 @@ function addTests() {
             expect(el1a.childNodes[0].className).to.equal('foo');
         });
 
+        it('should allow discarding to be skipped for a node', function() {
+            var el1a = document.createElement('div');
+            var el1b = document.createElement('b');
+            var el1c = document.createElement('span');
+            var el1d = document.createElement('a');
+            el1a.appendChild(el1b);
+            el1a.appendChild(el1c);
+            el1a.appendChild(el1d);
+
+            var el2a = document.createElement('div');
+            var el2b = document.createElement('a');
+            el2a.appendChild(el2b);
+
+            morphdom(el1a, el2a, {
+                onBeforeNodeDiscarded: function(el) {
+                    if (el.tagName === 'B') {
+                        return false;
+                    }
+                }
+            });
+
+            expect(el1a.childNodes[0].tagName).to.equal('B');
+            expect(el1a.childNodes[1].tagName).to.equal('A');
+        });
+
         it('should transform a simple el to a target HTML string', function() {
             var el1 = document.createElement('div');
             el1.innerHTML  = '<button>Click Me</button>';

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -146,6 +146,13 @@ function runTest(name, autoTest) {
 
     var elLookupBefore = buildElLookup(fromNode);
 
+    function onBeforeNodeDiscarded(node) {
+        if (node.$onBeforeNodeDiscarded) {
+            throw new Error('Duplicate oonBeforeNodeDiscarded for: ' + serializeNode(node));
+        }
+
+        node.$onBeforeNodeDiscarded = true;
+    }
     function onNodeDiscarded(node) {
         if (node.$onNodeDiscarded) {
             throw new Error('Duplicate onNodeDiscarded for: ' + serializeNode(node));
@@ -171,6 +178,7 @@ function runTest(name, autoTest) {
     }
 
     var morphedNode = morphdom(fromNode, toNode, {
+        onBeforeNodeDiscarded: onBeforeNodeDiscarded,
         onNodeDiscarded: onNodeDiscarded,
         onBeforeMorphEl: onBeforeMorphEl,
         onBeforeMorphElChildren: onBeforeMorphElChildren


### PR DESCRIPTION
This should resolve issue #4.
In my particular case, I have such problem that is resolved by this feature.

In [Catberry.js](https://github.com/catberry/catberry) I apply morphdom to `head` element and some third-party libraries add `script` or `style` tags into it (like lazy loading). So, after I render new `head` state and try to patch the existing `head` all these defered added third-party `style` and `script` tags are removed.

Therefore we need to have an ability to control this action.