### PR TITLE
add new option: ignoreFormValues

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,13 @@ var specialElHandlers = {
      * that "selected" is an attribute when reading
      * over the attributes using selectEl.attributes
      */
-    OPTION: function(fromEl, toEl) {
-        if ((fromEl.selected = toEl.selected)) {
-            fromEl.setAttribute('selected', '');
-        } else {
-            fromEl.removeAttribute('selected', '');
+    OPTION: function(fromEl, toEl, options) {
+        if (!options.ignoreFormValues) {
+            if ((fromEl.selected = toEl.selected)) {
+                fromEl.setAttribute('selected', '');
+            } else {
+                fromEl.removeAttribute('selected', '');
+            }
         }
     },
     /**
@@ -37,11 +39,13 @@ var specialElHandlers = {
      * no effect since it is only used to the set the initial value.
      * Similar for the "checked" attribute.
      */
-    INPUT: function(fromEl, toEl) {
-        fromEl.checked = toEl.checked;
+    INPUT: function(fromEl, toEl, options) {
+        if (!options.ignoreFormValues) {
+            fromEl.checked = toEl.checked;
 
-        if (fromEl.value != toEl.value) {
-            fromEl.value = toEl.value;
+            if (fromEl.value != toEl.value) {
+                fromEl.value = toEl.value;
+            }
         }
 
         if (!toEl.hasAttribute('checked')) {
@@ -53,10 +57,13 @@ var specialElHandlers = {
         }
     },
 
-    TEXTAREA: function(fromEl, toEl) {
+    TEXTAREA: function(fromEl, toEl, options) {
         var newValue = toEl.value;
-        if (fromEl.value != newValue) {
-            fromEl.value = newValue;
+
+        if (!options.ignoreFormValues) {
+            if (fromEl.value != newValue) {
+                fromEl.value = newValue;
+            }
         }
 
         if (fromEl.firstChild) {
@@ -325,7 +332,7 @@ function morphdom(fromNode, toNode, options) {
 
         var specialElHandler = specialElHandlers[fromEl.tagName];
         if (specialElHandler) {
-            specialElHandler(fromEl, toEl);
+            specialElHandler(fromEl, toEl, options);
         }
     } // END: morphEl(...)
 

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -301,6 +301,22 @@ function addTests() {
             expect(el1.value).to.equal('Hello World 2');
         });
 
+        it('should allow ignoring a text input value', function() {
+            var el1 = document.createElement('input');
+            el1.type = 'text';
+            el1.value = 'Hello World';
+
+            var el2 = document.createElement('input');
+            el2.setAttribute('type', 'text');
+            el2.setAttribute('value', 'Hello World 2');
+
+            morphdom(el1, el2, {
+                ignoreFormValues: true
+            });
+
+            expect(el1.value).to.equal('Hello World');
+        });
+
         it('should transform a checkbox input el', function() {
             var el1 = document.createElement('input');
             el1.type = 'checkbox';
@@ -314,6 +330,23 @@ function addTests() {
             morphdom(el1, el2);
 
             expect(el1.checked).to.equal(true);
+        });
+
+        it('should allow ingoring a checkbox value', function() {
+            var el1 = document.createElement('input');
+            el1.type = 'checkbox';
+            el1.setAttribute('checked', '');
+            el1.checked = false;
+
+            var el2 = document.createElement('input');
+            el2.setAttribute('type', 'text');
+            el2.setAttribute('checked', '');
+
+            morphdom(el1, el2, {
+                ignoreFormValues: true
+            });
+
+            expect(el1.checked).to.equal(false);
         });
 
         it('should transform an incompatible node and maintain the same parent', function() {
@@ -432,6 +465,21 @@ function addTests() {
             morphdom(el1, el2);
 
             expect(el1.firstChild.value).to.equal('bar');
+        });
+
+        it('should allow ignoring a textarea value', function() {
+            var el1 = document.createElement('div');
+            el1.innerHTML = '<textarea>foo</textarea>';
+            el1.firstChild.value = 'foo2';
+
+            var el2 = document.createElement('div');
+            el2.innerHTML = '<textarea>bar</textarea>';
+
+            morphdom(el1, el2, {
+                ignoreFormValues: true
+            });
+
+            expect(el1.firstChild.value).to.equal('foo2');
         });
 
         it('should not change caret position if input value did not change', function() {


### PR DESCRIPTION
This is useful for systems that try to separate the data flowing from javascript to DOM (morph) and data flowing in the opposite direction (form values).

It also allows to keep the separation between attributes and properties.