### PR TITLE
add option getNodeKey

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -124,6 +124,10 @@ function moveChildren(fromEl, toEl) {
     return toEl;
 }
 
+function defaultGetNodeKey(node) {
+    return node.id;
+}
+
 function morphdom(fromNode, toNode, options) {
     if (!options) {
         options = {};
@@ -135,6 +139,7 @@ function morphdom(fromNode, toNode, options) {
 
     var savedEls = {}; // Used to save off DOM elements with IDs
     var unmatchedEls = {};
+    var getNodeKey = options.getNodeKey || defaultGetNodeKey;
     var onNodeDiscarded = options.onNodeDiscarded || noop;
     var onBeforeMorphEl = options.onBeforeMorphEl || noop;
     var onBeforeMorphElChildren = options.onBeforeMorphElChildren || noop;
@@ -142,7 +147,7 @@ function morphdom(fromNode, toNode, options) {
     var childrenOnly = options.childrenOnly === true;
 
     function removeNodeHelper(node, nestedInSavedEl) {
-        var id = node.id;
+        var id = getNodeKey(node);
         // If the node has an ID then save it off since we will want
         // to reuse it in case the target DOM tree has a DOM element
         // with the same ID
@@ -169,7 +174,7 @@ function morphdom(fromNode, toNode, options) {
             while(curChild) {
 
 
-                if (!curChild.id) {
+                if (!getNodeKey(curChild)) {
                     // We only want to handle nodes that don't have an ID to avoid double
                     // walking the same saved element.
 
@@ -191,7 +196,7 @@ function morphdom(fromNode, toNode, options) {
 
         parentNode.removeChild(node);
         if (alreadyVisited) {
-            if (!node.id) {
+            if (!getNodeKey(node)) {
                 onNodeDiscarded(node);
                 walkDiscardedChildNodes(node);
             }
@@ -201,10 +206,10 @@ function morphdom(fromNode, toNode, options) {
     }
 
     function morphEl(fromEl, toEl, alreadyVisited, childrenOnly) {
-        if (toEl.id) {
+        if (getNodeKey(toEl)) {
             // If an element with an ID is being morphed then it is will be in the final
             // DOM so clear it out of the saved elements collection
-            delete savedEls[toEl.id];
+            delete savedEls[getNodeKey(toEl)];
         }
 
         if (!childrenOnly) {
@@ -231,10 +236,10 @@ function morphdom(fromNode, toNode, options) {
 
             outer: while(curToNodeChild) {
                 toNextSibling = curToNodeChild.nextSibling;
-                curToNodeId = curToNodeChild.id;
+                curToNodeId = getNodeKey(curToNodeChild);
 
                 while(curFromNodeChild) {
-                    var curFromNodeId = curFromNodeChild.id;
+                    var curFromNodeId = getNodeKey(curFromNodeChild);
                     fromNextSibling = curFromNodeChild.nextSibling;
 
                     if (!alreadyVisited) {

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -435,7 +435,6 @@ function addTests() {
         });
 
         it('should not change caret position if input value did not change', function() {
-
             var inputEl = document.createElement('input');
             inputEl.type = 'text';
             inputEl.value = 'HELLO';
@@ -460,8 +459,40 @@ function addTests() {
             update();
 
             expect(inputEl.selectionStart).to.equal(0);
+        });
 
+        it('should determine correct matching elements by id', function() {
+            var el1 = document.createElement('div');
+            el1.innerHTML = '<span id="span1"></span><span id="span2"></span>';
 
+            var el2 = document.createElement('div');
+            el2.innerHTML = '<span id="span2"></span>';
+
+            var span2 = el1.children[1];
+
+            var morphedEl = morphdom(el1, el2);
+
+            expect(morphedEl.children[0]).to.equal(span2);
+            expect(morphedEl.children.length).to.equal(1);
+        });
+
+        it('should determine correct matching elements by attribute "data-id"', function() {
+            var el1 = document.createElement('div');
+            el1.innerHTML = '<span data-id="1"></span><span data-id="2"></span>';
+
+            var el2 = document.createElement('div');
+            el2.innerHTML = '<span data-id="2"></span>';
+
+            var span2 = el1.children[1];
+
+            var morphedEl = morphdom(el1, el2, {
+                getNodeKey: function(el) {
+                    return el.dataset.id;
+                }
+            });
+
+            expect(morphedEl.children[0]).to.equal(span2);
+            expect(morphedEl.children.length).to.equal(1);
         });
     });
 }
@@ -469,5 +500,3 @@ function addTests() {
 if (require('../mocha-phantomjs/generated/config').runTests === true) {
     addTests();
 }
-
-


### PR DESCRIPTION
Sometimes you need a way to show that the elements are the same and do not always id perfect for this.
For example with the implementation of the component system you can to generate a key based on the component parameters. An example of key generation by dataset: [rista.View](https://github.com/Riim/rista/blob/8d97a1e36a6c265287ff8b3a7bf17aa20867e6a1/src/View.js#L173)

And `id` in this example [TodoApp](https://github.com/Riim/rista/blob/8d97a1e36a6c265287ff8b3a7bf17aa20867e6a1/examples/TodoApp.html#L84) no longer needed.

Related with https://github.com/patrick-steele-idem/morphdom/issues/27
