### PR TITLE
Support for IE7+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,8 +28,7 @@ function toElement(str) {
 function hasAttribute(el, name) {
     if (el.hasAttribute) {
         return el.hasAttribute(name);
-    }
-    else {
+    } else {
         return el.getAttributeNode(name) !== null;
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,13 +11,13 @@ function empty(o) {
     return true;
 }
 function toElement(str) {
-    if (!range) {
+    if (!range && document.createRange) {
         range = document.createRange();
         range.selectNode(document.body);
     }
 
     var fragment;
-    if (range.createContextualFragment) {
+    if (range && range.createContextualFragment) {
         fragment = range.createContextualFragment(str);
     } else {
         fragment = document.createElement('body');

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,14 @@ function toElement(str) {
     }
     return fragment.childNodes[0];
 }
+function hasAttribute(el, name) {
+    if (el.hasAttribute) {
+        return el.hasAttribute(name);
+    }
+    else {
+        return el.getAttributeNode(name) !== null;
+    }
+}
 
 var specialElHandlers = {
     /**
@@ -47,29 +55,17 @@ var specialElHandlers = {
      * Similar for the "checked" attribute.
      */
     INPUT: function(fromEl, toEl) {
-        var hasCheckedAttribute = false;
-        var hasValueAttribute = false;
-
         fromEl.checked = toEl.checked;
 
         if (fromEl.value != toEl.value) {
             fromEl.value = toEl.value;
         }
 
-        if (toEl.hasAttribute) {
-            hasCheckedAttribute = toEl.hasAttribute('checked');
-            hasValueAttribute = toEl.hasAttribute('value');
-        }
-        else {
-            hasCheckedAttribute = toEl.getAttribute('checked');
-            hasValueAttribute = toEl.getAttribute('value');
-        }
-
-        if (!hasCheckedAttribute) {
+        if (!hasAttribute(toEl, 'checked')) {
             fromEl.removeAttribute('checked');
         }
 
-        if (!hasValueAttribute) {
+        if (!hasAttribute(toEl, 'value')) {
             fromEl.removeAttribute('value');
         }
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,17 +47,29 @@ var specialElHandlers = {
      * Similar for the "checked" attribute.
      */
     INPUT: function(fromEl, toEl) {
+        var hasCheckedAttribute = false;
+        var hasValueAttribute = false;
+
         fromEl.checked = toEl.checked;
 
         if (fromEl.value != toEl.value) {
             fromEl.value = toEl.value;
         }
 
-        if (!toEl.hasAttribute('checked')) {
+        if (toEl.hasAttribute) {
+            hasCheckedAttribute = toEl.hasAttribute('checked');
+            hasValueAttribute = toEl.hasAttribute('value');
+        }
+        else {
+            hasCheckedAttribute = toEl.getAttribute('checked');
+            hasValueAttribute = toEl.getAttribute('value');
+        }
+
+        if (!hasCheckedAttribute) {
             fromEl.removeAttribute('checked');
         }
 
-        if (!toEl.hasAttribute('value')) {
+        if (!hasValueAttribute) {
             fromEl.removeAttribute('value');
         }
     },


### PR DESCRIPTION
Current version makes use of `document.createRange` and `Element.prototype.hasAttribute`, which are unavailable on older browsers.

This provides fallbacks for those scenarios.

This should resolve issue #32.