### PR TITLE
Adding Composer.js link in "Projects using morphdom" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ In theory, templating languages such as Marko could support two compiled outputs
 
 - __[Marko Widgets](https://github.com/marko-js/marko-widgets)__ (`v5.0.0-beta+`) - Marko Widgets is a high performance and lightweight UI components framework that uses the [Marko templating engine](https://github.com/marko-js/marko) for rendering UI components. You can see how Marko Widgets compares to React in performance by taking a look at the following benchmark: [Marko vs React: Performance Benchmark](https://github.com/patrick-steele-idem/marko-vs-react)
 - __[Catberry.js](https://github.com/catberry/catberry)__ (`v6.0.0+`) - Catberry is a framework with Flux architecture, isomorphic web-components and progressive rendering.
+- __[Composer.js](https://lyonbros.github.io/composer.js/)__ (`v1.2.1`) - Composer is a set of stackable libraries for building complex single-page apps. It uses morphdom in its rendering engine for efficient and non-destructive updates to the DOM.
 
 _NOTE: If you are using a `morphdom` in your project please send a PR to add your project here_
 


### PR DESCRIPTION
Hey, I was in the midst of updating the framework I build/maintain to use a virtual dom implementation. The road ahead was dark and every step forward may have revealed a mistake that would cost days in dev time I'd never get back. There were so many weird corner cases and unanswered questions. Then I found morphdom and realized there is no point to having a virtual DOM if you can just patch the DOM directly! This project, and the ideas behind it, saved me from so much useless work.

I implemented it within a few days (and wrote a ton of docs) and now Composer.js has a view system that's so much better than it was before (form elements retain their values/focus on re-render, trees of objects can preserve their DOM elements across renders, etc). It gives all the benefits of a vdom (except maybe what react-native is doing but I seriously don't have time to replicate that anyway) without having to deal with rebuilding a huge portion of the rendering system.

Thanks for your work on this. I'm going to slowly convert all my projects to use the new morphdom rendering as I have time.