### PR TITLE
Improve node lifecycle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,25 +69,37 @@ The returned value will typically be the `fromNode`. However, in situations wher
 
 Supported options (all optional):
 
-- **onBeforeNodeDiscarded** (`Function(node)`) - A function that will called before a `Node` in the `from` tree has been discarded. If the listener function returns `false` then the element will not be discarded.
-- **onNodeDiscarded** (`Function(node)`) - A function that will called when a `Node` in the `from` tree has been discarded and will no longer exist in the final DOM tree.
-- **onBeforeMorphEl** (`Function(fromEl, toEl)`) - A function that will called when a `HTMLElement` in the `from` tree is about to be morphed. If the listener function returns `false` then the element will be skipped.
-- **onBeforeMorphElChildren** (`Function(fromEl, toEl)`) - A function that will called when the children of an `HTMLElement` in the `from` tree are about to be morphed. If the listener function returns `false` then the child nodes will be skipped.
-- **childrenOnly** (`Boolean`) - If `true` then only the children of the `fromEl` and `toEl` nodes will be morphed (the containing element will be skipped). Defaults to `false`.
+- **onBeforeNodeAdded** (`Function(node)`) - Called before a `Node` in the `to` tree is added to the `from` tree. If this function returns `false` then the node will not be added.
+- **onNodeAdded** (`Function(node)`) - Called after a `Node` in the `to` tree has been added to the `from` tree.
+- **onBeforeElUpdated** (`Function(fromEl, toEl)`) - Called before a `HTMLElement` in the `from` tree is updated. If this function returns `false` then the element will not be updated.
+- **onElUpdated** (`Function(el)`) - Called after a `HTMLElement` in the `from` tree has been updated.
+- **onBeforeNodeDiscarded** (`Function(node)`) - Called before a `Node` in the `from` tree is discarded. If this function returns `false` then the node will not be discarded.
+- **onNodeDiscarded** (`Function(node)`) - Called after a `Node` in the `from` tree has been discarded.
+- **onBeforeElChildrenUpdated** (`Function(fromEl, toEl)`) - Called before the children of a `HTMLElement` in the `from` tree are updated. If this function returns `false` then the child nodes will not be updated.
+- **childrenOnly** (`Boolean`) - If `true` then only the children of the `fromNode` and `toNode` nodes will be morphed (the containing element will be skipped). Defaults to `false`.
 
 ```javascript
 var morphdom = require('morphdom');
 var morphedNode = morphdom(fromNode, toNode, {
+    onBeforeNodeAdded: function(node) {
+        return true;
+    },
+    onNodeAdded: function(node) {
+
+    },
+    onBeforeElUpdated: function(fromEl, toEl) {
+        return true;
+    },
+    onElUpdated: function(el) {
+
+    },
     onBeforeNodeDiscarded: function(node) {
         return true;
     },
     onNodeDiscarded: function(node) {
 
     },
-    onBeforeMorphEl: function(fromEl, toEl) {
-        return true;
-    },
-    onBeforeMorphElChildren: function(fromEl, toEl) {
+    onBeforeElChildrenUpdated: function(fromEl, toEl) {
         return true;
     },
     childrenOnly: false

--- a/lib/index.js
+++ b/lib/index.js
@@ -164,10 +164,13 @@ function morphdom(fromNode, toNode, options) {
     var savedEls = {}; // Used to save off DOM elements with IDs
     var unmatchedEls = {};
     var getNodeKey = options.getNodeKey || defaultGetNodeKey;
-    var onNodeDiscarded = options.onNodeDiscarded || noop;
-    var onBeforeMorphEl = options.onBeforeMorphEl || noop;
-    var onBeforeMorphElChildren = options.onBeforeMorphElChildren || noop;
+    var onBeforeNodeAdded = options.onBeforeNodeAdded || noop;
+    var onNodeAdded = options.onNodeAdded || noop;
+    var onBeforeElUpdated = options.onBeforeElUpdated || options.onBeforeMorphEl || noop;
+    var onElUpdated = options.onElUpdated || noop;
     var onBeforeNodeDiscarded = options.onBeforeNodeDiscarded || noop;
+    var onNodeDiscarded = options.onNodeDiscarded || noop;
+    var onBeforeElChildrenUpdated = options.onBeforeElChildrenUpdated || options.onBeforeMorphElChildren || noop;
     var childrenOnly = options.childrenOnly === true;
     var movedEls = [];
 
@@ -239,13 +242,14 @@ function morphdom(fromNode, toNode, options) {
         }
 
         if (!childrenOnly) {
-            if (onBeforeMorphEl(fromEl, toEl) === false) {
+            if (onBeforeElUpdated(fromEl, toEl) === false) {
                 return;
             }
 
             morphAttrs(fromEl, toEl);
+            onElUpdated(fromEl);
 
-            if (onBeforeMorphElChildren(fromEl, toEl) === false) {
+            if (onBeforeElChildrenUpdated(fromEl, toEl) === false) {
                 return;
             }
         }
@@ -339,7 +343,10 @@ function morphdom(fromNode, toNode, options) {
                 // If we got this far then we did not find a candidate match for our "to node"
                 // and we exhausted all of the children "from" nodes. Therefore, we will just
                 // append the current "to node" to the end
-                fromEl.appendChild(curToNodeChild);
+                if (onBeforeNodeAdded(curToNodeChild) !== false) {
+                    fromEl.appendChild(curToNodeChild);
+                    onNodeAdded(curToNodeChild);
+                }
 
                 if (curToNodeChild.nodeType === 1 && (curToNodeId || curToNodeChild.firstChild)) {
                     // The element that was just added to the original DOM may have


### PR DESCRIPTION
I've added `onNodeAdded` as discussed in https://github.com/patrick-steele-idem/morphdom/issues/45. I might have overlooked any edge cases as you pointed out, but I'm just putting it here for review.

I added a few more options to cover what a typical user might expect and updated the naming accordingly. There is now:
- `onBeforeNodeAdded`
- `onNodeAdded`
- `onBeforeNodeUpdated`
- `onNodeUpdated`
- `onBeforeNodeDiscarded`
- `onNodeDiscarded`
- `onNodeChildrenUpdated`
- `childrenOnly`

This is far more clear and consistent in my opinion. Being the pedant I am, my reason for changing `onBeforeMorphEl` to `onBeforeNodeUpdated` is that I believe morphing means adding, updating and discarding, hence the collective description `morphdom`. It's a backwards compatible change anyhow.