### PR TITLE
Support full page html diff

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,7 +158,13 @@ function morphdom(fromNode, toNode, options) {
     }
 
     if (typeof toNode === 'string') {
-        toNode = toElement(toNode);
+        if (fromNode.nodeName === '#document' || fromNode.nodeName === 'HTML') {
+            var toNodeHtml = toNode;
+            toNode = document.createElement('html');
+            toNode.innerHTML = toNodeHtml;
+        } else {
+            toNode = toElement(toNode);
+        }
     }
 
     var savedEls = {}; // Used to save off DOM elements with IDs

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -403,6 +403,20 @@ function addTests() {
             expect(el1.firstChild.tagName).to.equal('BUTTON');
         });
 
+        it('should transform an html document el to a target HTML string', function() {
+            var el1 = document.createElement('html');
+            el1.innerHTML = '<html><head><title>Test</title></head><body>a</body></html>';
+
+            expect(el1.firstChild.nextSibling.innerHTML).to.equal('a');
+
+            morphdom(el1, '<html><head><title>Test</title></head><body>b</body></html>');
+
+            expect(el1.tagName).to.equal('HTML');
+            expect(el1.firstChild.tagName).to.equal('HEAD');
+            expect(el1.firstChild.nextSibling.tagName).to.equal('BODY');
+            expect(el1.firstChild.nextSibling.innerHTML).to.equal('b');
+        });
+
         it('should allow only morphing child nodes', function() {
             var el1 = document.createElement('div');
             el1.className = 'foo';


### PR DESCRIPTION
I may be missing something but this seems to be the simplest fix to allow a full page html diff.
This lets you do stuff like this:

```js
morph(document.documentElement, `
    <html>
        <head>
            <title>Hello</title>
        </head>
        <body>
            Content
        </body>
    <html>
`);