### PR TITLE
Fix: form elements lose class when removing name attribute in MSIE 8-11 and MS Edge #71

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -187,7 +187,12 @@ function morphAttrs(fromNode, toNode) {
             attrNamespaceURI = attr.namespaceURI;
 
             if (!hasAttributeNS(toNode, attrNamespaceURI, attrNamespaceURI ? attrName = attr.localName || attrName : attrName)) {
-                fromNode.removeAttributeNode(attr);
+                if (attrNamespaceURI) {
+                    fromNode.removeAttributeNS(attrNamespaceURI, attr.localName);
+                }
+                else {
+                    fromNode.removeAttribute(attrName);
+                }
             }
         }
     }


### PR DESCRIPTION
Removing a name attribute using removeAttributeNode method also empties the class attribute in MSIE and MS Edge browsers (probably a browser bug). Use of removeAttribute/removeAttributeNS methods seems to suppress this behavior.