### PR TITLE
add yo-yo and thus choo

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ In theory, templating languages such as Marko could support two compiled outputs
 - __[Marko Widgets](https://github.com/marko-js/marko-widgets)__ (`v5.0.0-beta+`) - Marko Widgets is a high performance and lightweight UI components framework that uses the [Marko templating engine](https://github.com/marko-js/marko) for rendering UI components. You can see how Marko Widgets compares to React in performance by taking a look at the following benchmark: [Marko vs React: Performance Benchmark](https://github.com/patrick-steele-idem/marko-vs-react)
 - __[Catberry.js](https://github.com/catberry/catberry)__ (`v6.0.0+`) - Catberry is a framework with Flux architecture, isomorphic web-components and progressive rendering.
 - __[Composer.js](https://lyonbros.github.io/composer.js/)__ (`v1.2.1`) - Composer is a set of stackable libraries for building complex single-page apps. It uses morphdom in its rendering engine for efficient and non-destructive updates to the DOM.
+- __[yo-yo.js](https://github.com/maxogden/yo-yo)__ (`v1.2.2`) - A tiny library for building modular UI components using DOM diffing and ES6 tagged template literals. yo-yo powers a tiny, isomorphic framework called [choo](https://github.com/yoshuawuyts/choo) (`v3.3.0`), which is designed to be fun.
 
 _NOTE: If you are using a `morphdom` in your project please send a PR to add your project here_
 


### PR DESCRIPTION
Hi, yo-yo and choo aren't my projects, but they use morphdom. (morphdom powers yo-yo, and yo-yo powers choo.)

I just threw the latest version numbers in there, sorry -- I got the impression the format's supposed to track how long morphdom's been involved, i.e., since which version, but I wasn't totally sure. Can fix if you want.