### PR TITLE
ie: fix textarea with placeholder on IE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,12 @@ var specialElHandlers = {
         }
 
         if (fromEl.firstChild) {
+            // Needed for IE. Apparently IE sets the placeholder as the
+            // node value and vise versa. This ignores an empty update.
+            if (
+              newValue === '' &&
+              fromEl.firstChild.nodeValue === fromEl.placeholder
+            ) return;
             fromEl.firstChild.nodeValue = newValue;
         }
     }

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -590,6 +590,22 @@ function addTests() {
             expect(el1.firstChild.value).to.equal('bar');
         });
 
+        it('should preserve placeholder in an empty textarea el', function() {
+            var el1 = document.createElement('div');
+            el1.innerHTML = '<textarea placeholder="foo"></textarea>';
+            var textarea1 = el1.firstChild;
+
+            // Special test for IE behavior.
+            if (textarea1.firstChild && textarea1.firstChild.nodeValue === 'foo') {
+              var el2 = document.createElement('div');
+              el2.innerHTML = '<textarea placeholder="foo"></textarea>';
+
+              morphdom(el1, el2);
+
+              expect(textarea1.firstChild.nodeValue).to.equal('foo');
+            }
+        });
+
         it('should not change caret position if input value did not change', function() {
             var inputEl = document.createElement('input');
             inputEl.type = 'text';


### PR DESCRIPTION
hey all, here's a pull request for a bug i was experiencing in Internet Explorer 11.

without this change, morphing an existing textarea with a new textarea containing an empty value will cause the placeholder to disappear.

this change checks for that case and ignores the update.

keen to hear feedback on what y'all think of this.
