### PR TITLE
Fix loosing cursor position in Edge

### DIFF
--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -51,7 +51,9 @@ export default {
                 return;
             }
 
-            fromEl.firstChild.nodeValue = newValue;
+            if (fromEl.firstChild && fromEl.firstChild.nodeValue !== newValue) {
+             fromEl.firstChild.nodeValue = newValue;
+           }
         }
     },
     SELECT: function(fromEl, toEl) {


### PR DESCRIPTION
If we set nodeValue to the same value, Edge(maybe some other browsers)
reset the cursor position. This results in problems with typing for
textareas connected to data via morphdom.

Let's check and update the value only if it's changed. This fixes typing issues.