### PR TITLE
Remove nonexistent second-argument from Element.removeAttribute()

### DIFF
--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -6,7 +6,7 @@ function syncBooleanAttrProp(fromEl, toEl, name) {
         if (fromEl[name]) {
             fromEl.setAttribute(name, '');
         } else {
-            fromEl.removeAttribute(name, '');
+            fromEl.removeAttribute(name);
         }
     }
 }


### PR DESCRIPTION
As illustrated in https://developer.mozilla.org/en-US/docs/Web/API/Element/removeAttribute, `removeAttribute()` only has one argument.