### PR TITLE
Check isSameNode on fromNode

### DIFF
--- a/src/morphdom.js
+++ b/src/morphdom.js
@@ -167,6 +167,10 @@ export default function morphdomFactory(morphAttrs) {
             }
         }
 
+        function isSameNode(toNode, fromNode) {
+            return (toNode.isSameNode && toNode.isSameNode(fromNode)) || (fromNode.isSameNode && fromNode.isSameNode(toNode));
+        }
+
         function morphEl(fromEl, toEl, childrenOnly) {
             var toElKey = getNodeKey(toEl);
             var curFromNodeKey;
@@ -177,7 +181,7 @@ export default function morphdomFactory(morphAttrs) {
                 delete fromNodesLookup[toElKey];
             }
 
-            if (toNode.isSameNode && toNode.isSameNode(fromNode)) {
+            if (isSameNode(toNode, fromNode)) {
                 return;
             }
 
@@ -210,7 +214,7 @@ export default function morphdomFactory(morphAttrs) {
                     while (curFromNodeChild) {
                         fromNextSibling = curFromNodeChild.nextSibling;
 
-                        if (curToNodeChild.isSameNode && curToNodeChild.isSameNode(curFromNodeChild)) {
+                        if (isSameNode(curToNodeChild, curFromNodeChild)) {
                             curToNodeChild = toNextSibling;
                             curFromNodeChild = fromNextSibling;
                             continue outer;

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -784,6 +784,28 @@ describe('morphdom' , function() {
         expect(el1.querySelector('#skipMeChild') != null).to.equal(true);
     });
 
+    it('should use isSameNode to allow out of morphdom managed elements', function() {
+        var containEl1 = document.createElement('div');
+        containEl1.innerHTML = '<p>Jackie Brown</p>'
+        var containRegion1 = document.createElement('div');
+        var childview = document.createElement('p');
+        childview.innerHTML = 'by Quentin Tarantino';
+        containRegion1.appendChild(childview);
+        containEl1.appendChild(containRegion1);
+
+        var containEl2 = document.createElement('div');
+        containEl2.innerHTML = '<p>Pulp Fiction</p>';
+        var containRegion2 = document.createElement('div');
+        containEl2.appendChild(containRegion2);
+
+        containRegion1.isSameNode = function() {
+            return true;
+        };
+
+        morphdom(containEl1, containEl2);
+        expect(containEl1.innerHTML).to.equal('<p>Pulp Fiction</p><div><p>by Quentin Tarantino</p></div>');
+    });
+
     it('should use isSameNode to allow reference proxies', function() {
         var el1 = document.createElement('div');
         el1.innerHTML = 'stay gold';


### PR DESCRIPTION
Because sometimes we already know from where we are, how the current el is and which nodes should be skipped for update.
Better to do this than walking the newEl to find matches on current el and add `isSameNode` on those or using hooks.