### PR TITLE
better handle elements with duplicate ids

### DIFF
--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -748,6 +748,39 @@ describe('morphdom' , function() {
         expect(finalEl.innerHTML).to.equal('<div id="boo"></div>');
     });
 
+    it('deal with duplicate ids before', function() {
+        var el1 = document.createElement('div');
+        el1.innerHTML = '<span id="foo"></span><span id="boo"><span id="foo"></span></span>';
+
+        var el2 = document.createElement('div');
+        el2.innerHTML = '<span id="boo"><span id="foo"></span></span>';
+
+        var finalEl = morphdom(el1, el2);
+        expect(finalEl.innerHTML).to.equal('<span id="boo"><span id="foo"></span></span>');
+    });
+
+    it('deal with duplicate ids after', function() {
+        var el1 = document.createElement('div');
+        el1.innerHTML = '<span id="boo"><span id="foo"></span></span><span id="foo"></span>';
+
+        var el2 = document.createElement('div');
+        el2.innerHTML = '<span id="boo"><span id="foo"></span></span>';
+
+        var finalEl = morphdom(el1, el2);
+        expect(finalEl.innerHTML).to.equal('<span id="boo"><span id="foo"></span></span>');
+    });
+
+    it('deal with duplicate ids as siblings', function() {
+        var el1 = document.createElement('div');
+        el1.innerHTML = '<span id="boo"><span id="foo"></span><span id="foo"></span></span>';
+
+        var el2 = document.createElement('div');
+        el2.innerHTML = '<span id="boo"><span id="foo"></span></span>';
+
+        var finalEl = morphdom(el1, el2);
+        expect(finalEl.innerHTML).to.equal('<span id="boo"><span id="foo"></span></span>');
+    });
+
     it('should not remove keyed elements that are part of a DOM subtree that is skipped using onBeforeElUpdated', function() {
         var el1 = document.createElement('div');
         el1.innerHTML = '<span id="skipMe"><span id="skipMeChild"></span></span>';


### PR DESCRIPTION
In a situation where we have elements with duplicate ids, morphdom won't let us recover to a better state.  

When we try and morph an existing `fromNode` ...

```html
<section>
  <div id="A">
    <div id="B"></div>
  </div>
  <div id="B"></div>
</section>
```
... to a `toNode` where we remove the duplicate `B` ...

```html
<section>
  <div id="A">
    <div id="B"></div>
  </div>
</section>
```
... we actually end up exactly where we started, with the duplicate `B` still in place in `fromNode`.

This PR compares morphed element objects directly rather than just their ids when testing whether to remove elements slated for removal.  That way we see that the duplicate `B` wasn't actually morphed and so it is safe to get rid of it.
