### PR TITLE
fixed namespaced attributes not updating

### DIFF
--- a/src/morphAttrs.js
+++ b/src/morphAttrs.js
@@ -16,11 +16,17 @@ export default function morphAttrs(fromNode, toNode) {
         attrValue = attr.value;
 
         if (attrNamespaceURI) {
-            attrName = attr.localName || attrName;
-            fromValue = fromNode.getAttributeNS(attrNamespaceURI, attrName);
+            var attrLocalName = attr.localName
 
+            // Important: getAttributeNS expects the localName of a namespaced attribute
+            // but setAttributeNS requires the fully qualified name
+            // ref: https://dom.spec.whatwg.org/#dom-element-getattributens
+            // ref: https://www.w3.org/TR/DOM-Level-2-Core/glossary.html#dt-localname
+            // ref: https://dom.spec.whatwg.org/#dom-element-setattributens
+            // ref: https://www.w3.org/TR/DOM-Level-2-Core/glossary.html#dt-qualifiedname
+            fromValue = fromNode.getAttributeNS(attrNamespaceURI, attrLocalName)
             if (fromValue !== attrValue) {
-                fromNode.setAttributeNS(attrNamespaceURI, attrName, attrValue);
+                fromNode.setAttributeNS(attrNamespaceURI, attrName, attrValue)
             }
         } else {
             fromValue = fromNode.getAttribute(attrName);


### PR DESCRIPTION
fixes #124 

Using SVG sprites with `<use xlink:href="" />` will not update the icon.

The reason is that `getAttributeNS` and `setAttributeNS` DOM APIs are inconsistent in it's arguments.
E.g.: lets say 'foo:bar' ('foo' being the namespace and 'bar' the local attribute name):
- `getAttributeNS` only needs the `localName`, i.e. `getAttributeNS('https://www.w3.org/1999/foo', 'bar');`
   > [`getAttributeNS(namespace, localName)`](https://dom.spec.whatwg.org/#dom-element-getattributens)
   > https://www.w3.org/TR/DOM-Level-2-Core/glossary.html#dt-localname
   > A local name is the local part of a qualified name. This is called the local part in Namespaces in XML [Namespaces].
- **BUT** `setAttributeNS` expects it's fully qualified name, i.e. `getAttributeNS('https://www.w3.org/1999/foo', 'foo:bar');`
   > [`setAttributeNS(namespace, qualifiedName, value)`](https://dom.spec.whatwg.org/#dom-element-setattributens)
   > https://www.w3.org/TR/DOM-Level-2-Core/glossary.html#dt-qualifiedname
   > A qualified name is the name of an element or attribute defined as the concatenation of a local name (as defined in this specification), optionally preceded by a namespace prefix and colon character. See Qualified Names in Namespaces in XML [Namespaces].