### PR TITLE
Fix select behavior when using optgroups

### DIFF
--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -60,7 +60,11 @@ export default {
     SELECT: function(fromEl, toEl) {
         if (!hasAttributeNS(toEl, null, 'multiple')) {
             var selectedIndex = -1;
-            var options = toEl.getElementsByTagName('option');
+            // We have to loop through children of fromEl, not toEl since nodes can be moved
+            // from toEl to fromEl directly when morphing.
+            // At the time this special handler is invoked, all children have already been morphed
+            // and appended to / removed from fromEl, so using fromEl here is safe and correct.
+            var options = fromEl.getElementsByTagName('option');
             var curChild;
             for (var i = 0; i < options.length; i++) {
                 curChild = options[i];

--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -60,21 +60,17 @@ export default {
     SELECT: function(fromEl, toEl) {
         if (!hasAttributeNS(toEl, null, 'multiple')) {
             var selectedIndex = -1;
-            var i = 0;
-            var curChild = toEl.firstChild;
-            while(curChild) {
-                var nodeName = curChild.nodeName;
-                if (nodeName && nodeName.toUpperCase() === 'OPTION') {
-                    if (hasAttributeNS(curChild, null, 'selected')) {
-                        selectedIndex = i;
-                        break;
-                    }
-                    i++;
+            var options = toEl.getElementsByTagName('option');
+            var curChild;
+            for (var i = 0; i < options.length; i++) {
+                curChild = options[i];
+                if (hasAttributeNS(curChild, null, 'selected')) {
+                    selectedIndex = i;
+                    break;
                 }
-                curChild = curChild.nextSibling;
             }
 
-            fromEl.selectedIndex = i;
+            fromEl.selectedIndex = selectedIndex;
         }
     }
 };


### PR DESCRIPTION
There is currently a bug where if a selected `<option>` is not the direct child of a `<select>`, it will not be properly selected. This becomes a problem when using `<optgroup>`s which put an extra layer between the select and the options. Here's a jsfiddle that demonstrates the issue: https://jsfiddle.net/28h97n0b/10/. Note how the value of the select never changes.

This fixes it by iterating over `toEl.getElementsByTagName('option')` instead of only iterating over direct children of `toEl`.

This has a decent amount of code overlap with #117, but fixes a different issue.