### PR TITLE
Use attribute name with the prefix in XMLNS namespace

### DIFF
--- a/src/morphAttrs.js
+++ b/src/morphAttrs.js
@@ -19,6 +19,9 @@ export default function morphAttrs(fromNode, toNode) {
             fromValue = fromNode.getAttributeNS(attrNamespaceURI, attrName);
 
             if (fromValue !== attrValue) {
+                if (attr.prefix === 'xmlns'){
+                    attrName = attr.name; // It's not allowed to set an attribute with the XMLNS namespace without specifying the `xmlns` prefix
+                }
                 fromNode.setAttributeNS(attrNamespaceURI, attrName, attrValue);
             }
         } else {


### PR DESCRIPTION
Hi,

It appears this project doesn't have a regular maintainer for now. I have a patch that makes it work with SVG icons properly in the Samsung Internet Browser. Hope, it would help someone someday.

---

Specification requires `xmlns` prefix to be specified when setting an attribute with the XMLNS namespace [1].

Quick check:

    > document.createElement('div').setAttributeNS('http://www.w3.org/2000/xmlns/', 'foo', 'bar')
    < Uncaught DOMException: Failed to execute 'setAttributeNS' on 'Element': 'http://www.w3.org/2000/xmlns/' is an invalid namespace for attributes.

    > document.createElement('div').setAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:foo', 'bar')
    < undefined

Stumbled upon this problem when morphpdom was updating the following DOM node in Samsung Internet Browser (!) on Android from

    <use xlink:href="#icon-iconset-warning"></use>

to

    <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-iconset-warning"></use>

and it was breaking at `setAttibuteNS('http://www.w3.org/2000/xmlns/', 'xlink', 'http://www.w3.org/1999/xlink')`, since that attribute was missing on the original node.

When, for instance, Chrome doesn't add the `xmlns:xlink` attribute in the first place and thus it doesn't have this problem.

1. https://www.w3.org/TR/dom/#dom-element-setattributens