### PR TITLE
skipMorph flag for text elements

### DIFF
--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -44,7 +44,7 @@ export default {
         syncBooleanAttrProp(fromEl, toEl, 'checked');
         syncBooleanAttrProp(fromEl, toEl, 'disabled');
 
-        if (fromEl.value !== toEl.value) {
+        if (!fromEl.skipMorph && fromEl.value !== toEl.value) {
             fromEl.value = toEl.value;
         }
 
@@ -55,7 +55,7 @@ export default {
 
     TEXTAREA: function(fromEl, toEl) {
         var newValue = toEl.value;
-        if (fromEl.value !== newValue) {
+        if (!fromEl.skipMorph && fromEl.value !== newValue) {
             fromEl.value = newValue;
         }
 


### PR DESCRIPTION
Howdy! I am part of the [StimulusReflex](https://docs.stimulusreflex.com) team. SR is a Ruby on Rails library which uses morphdom to do real-time updates delivered over websockets. It's similar to Phoenix LiveView.

One of the thorny issues that both StimulusReflex and LiveView have struggled with is the idea that the client should be the single source of truth. It's never acceptable to have the server update the text input element that you're currently typing into. We've used your `onBeforeElUpdated` callback to make sure that this doesn't happen.

The problem is that all mutations are skipped. What we've come to realize is that we'd very much like to morph update *everything except for the text*. This allows for things like changing CSS properties if the text you input into an element would fail a validation, for example.

This PR is tiny but it allows us to do this:

![success](https://user-images.githubusercontent.com/38150464/79696491-0a964600-824b-11ea-836d-454667854c3d.gif)

In the above example, we're updating the background color via websockets->morphdom every time they type a letter. This PR makes it possible.

If you're not wild about the skipMorph variable name, we're not emotionally attached. Also, this PR doesn't (yet) attempt to check for the skipMorph flag on SELECT elements. This was a pragmatic/strategic conservativism because we are hoping this patch is currently uncontroversial and welcomed. SELECT is a fair bit more complex but we'd be happy to make further commits if you're open to it... it's just a far less significant use case than input elements, in our view.