### PR TITLE
Perform diff when `toNode` is a DocumentFragment

### DIFF
--- a/src/morphdom.js
+++ b/src/morphdom.js
@@ -31,10 +31,8 @@ export default function morphdomFactory(morphAttrs) {
             } else {
                 toNode = toElement(toNode);
             }
-        } else if (toNode.nodeType === DOCUMENT_FRAGMENT_NODE) {
-          var div = document.createElement('div');
-          div.appendChild(toNode);
-          toNode = toElement(div.innerHTML);
+        } else if (toNode.nodeType === DOCUMENT_FRAGMENT_NODE && toNode.firstElementChild) {
+          toNode = toNode.firstElementChild;
         }
 
         var getNodeKey = options.getNodeKey || defaultGetNodeKey;

--- a/src/morphdom.js
+++ b/src/morphdom.js
@@ -31,6 +31,10 @@ export default function morphdomFactory(morphAttrs) {
             } else {
                 toNode = toElement(toNode);
             }
+        } else if (toNode.nodeType === DOCUMENT_FRAGMENT_NODE) {
+          var div = document.createElement('div');
+          div.appendChild(toNode);
+          toNode = toElement(div.innerHTML);
         }
 
         var getNodeKey = options.getNodeKey || defaultGetNodeKey;


### PR DESCRIPTION
From what I can tell, Morphdom does not perform a diff when `toNode` is a `DocumentFragment`. Instead, morphdom _completely replaces_ the old HTML with the new HTML.

This behavior can cause unexpected results, such as event listeners disappearing — even though the markup for the event trigger hasn't changed.

Below is an example where a `<div>` is morphed into the content of a `<template>` tag. Clicking the `<button>` will output a message to the console. A simple morph is performed after 2 seconds, and even though the text content of the `<h1>` is the only thing that changed, the event listener on the `<button>` is broken — because technically the original `<button`> has been nuked.

```html
<div>
  <h1>The button works 👇</h1>
  <button>Click me</button>
</div>

<template>
  <div>
    <h1>The button is broken 💥</h1>
    <button>Click me</button>
  </div>
</template>

<script>
  document.querySelector('button').addEventListener('click', (event) => {
    console.log(`Clicked ${(new Date).getTime()}`);
  });

  const fromNode = document.querySelector('div')
  const toNode = document.querySelector('template').cloneNode(true)

  setTimeout(() => morphdom(fromNode, toNode.content), 2000)
</script>
```

This PR includes a patch to fix this behavior. Here's a live test case of each:

- 💥 [Current behavior](https://kylefox.ca/morphdom-issue/broken.html) (Element is replaced)
- 🎉 [Patched behavior](https://kylefox.ca/morphdom-issue/fixed.html) (Element is diffed)

My fix works by placing the `DocumentFragment`'s contents inside a div, and then using the div's `innerHTML` as the string against which the diff should be applied.

However, I see some some tests are now failing. I'm also unsure about the side-effects my patch might introduce.

Before I continue working on this (including adding/fixing tests) I'd love to know if I'm even on the right track. Will this general approach work, or is morphing to document fragments more nuanced?