### PR TITLE
Fix morphing incompatible elements with matching IDs

### DIFF
--- a/src/morphdom.js
+++ b/src/morphdom.js
@@ -300,6 +300,7 @@ export default function morphdomFactory(morphAttrs) {
                                             }
 
                                             curFromNodeChild = matchingFromEl;
+                                            curFromNodeKey = getNodeKey(curFromNodeChild);
                                         }
                                     } else {
                                         // The nodes are not compatible since the "to" node has a key and there

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -429,6 +429,21 @@ describe('morphdom' , function() {
         expect(el1.children[1].textContent).to.equal('B');
     });
 
+    it('incompatible matching ids are morphed correctly', function() {
+        var el1 = document.createElement('div');
+        el1.innerHTML = `<h1 id="foo" class="foo">A</h1> <h2 id="matching" class="bar">B</h2>`;
+
+        var el2 = document.createElement('div');
+        el2.innerHTML = '<h1 id="matching" class="baz">C</h1>';
+
+        morphdom(el1, el2);
+
+        expect(el1.children.length).to.equal(1);
+        expect(el1.children[0].id).to.equal('matching');
+        expect(el1.children[0].className).to.equal('baz');
+        expect(el1.children[0].textContent).to.equal('C');
+    });
+
     it('should transform a text input el', function() {
         var el1 = document.createElement('input');
         el1.type = 'text';


### PR DESCRIPTION
This PR fixes an issue when morphing an element that has a matching `id` but different tag in the destination, eg:

```html
<div>
  <h1 id="foo" class="foo">A</h1> 
  <h2 id="matching" class="bar">B</h2>
</div>
```

to: 

```html
<div>
  <h1 id="matching" class="baz">C</h1>
</div>
```

Prior to this change, the result would incorrectly retain the original element:

```html
<div>
  <h2 id="matching" class="bar">B</h2>
  <h1 id="matching" class="baz">C</h1>
</div>
```

After this change, the result only contains the new element:

```html
<div>
  <h1 id="matching" class="baz">C</h1>
</div>
```