### PR TITLE
remove unreachable conditional

### DIFF
--- a/src/morphdom.js
+++ b/src/morphdom.js
@@ -435,10 +435,6 @@ export default function morphdomFactory(morphAttrs) {
       // toss out the "from node" and use the "to node"
       onNodeDiscarded(fromNode);
     } else {
-      if (toNode.isSameNode && toNode.isSameNode(morphedNode)) {
-        return;
-      }
-
       morphEl(morphedNode, toNode, childrenOnly);
 
       // We now need to loop over any keyed nodes that might need to be


### PR DESCRIPTION
The `isSameNode` func is [same as](https://developer.mozilla.org/en-US/docs/Web/API/Node/isSameNode) `===`, so the if conditional always unreachable