### PR TITLE
fix keyed lookup when using a cloned node in onBeforeElUpdated

### DIFF
--- a/src/morphdom.js
+++ b/src/morphdom.js
@@ -212,6 +212,11 @@ export default function morphdomFactory(morphAttrs) {
           return;
         } else if (beforeUpdateResult instanceof HTMLElement) {
           fromEl = beforeUpdateResult;
+          // reindex the new fromEl in case it's not in the same
+          // tree as the original fromEl
+          // (Phoenix LiveView sometimes returns a cloned tree,
+          //  but keyed lookups would still point to the original tree)
+          indexTree(fromEl);
         }
 
         // update attributes on original DOM element first


### PR DESCRIPTION
When returning a cloned element in onBeforeElUpdated, the keyed nodes would still point to the original tree. If morphdom then tries to remove an element it actually removed it from the DOM instead of removing it from the cloned node. This is only ever a problem if a cloned node is returned in onBeforeElUpdated, which is something that Phoenix LiveView does sometimes.

@chrismccord maybe we can add a check to only reindex if necessary, but I'm not sure how to best check this.