### PR TITLE
fix: should not clear selectedIndex when morphing option directly

### DIFF
--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -11,28 +11,13 @@ function syncBooleanAttrProp(fromEl, toEl, name) {
 
 export default {
     OPTION: function(fromEl, toEl) {
-        var parentNode = fromEl.parentNode;
-        if (parentNode) {
-            var parentName = parentNode.nodeName.toUpperCase();
-            if (parentName === 'OPTGROUP') {
-                parentNode = parentNode.parentNode;
-                parentName = parentNode && parentNode.nodeName.toUpperCase();
-            }
-            if (parentName === 'SELECT' && !parentNode.hasAttribute('multiple')) {
-                if (fromEl.hasAttribute('selected') && !toEl.selected) {
-                    // Workaround for MS Edge bug where the 'selected' attribute can only be
-                    // removed if set to a non-empty value:
-                    // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12087679/
-                    fromEl.setAttribute('selected', 'selected');
-                    fromEl.removeAttribute('selected');
-                }
-                // We have to reset select element's selectedIndex to -1, otherwise setting
-                // fromEl.selected using the syncBooleanAttrProp below has no effect.
-                // The correct selectedIndex will be set in the SELECT special handler below.
-                parentNode.selectedIndex = -1;
-            }
+        if (fromEl.hasAttribute('selected') && !toEl.selected) {
+            // Workaround for MS Edge bug where the 'selected' attribute can only be
+            // removed if set to a non-empty value:
+            // https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/12087679/
+            fromEl.setAttribute('selected', 'selected');
+            fromEl.removeAttribute('selected');
         }
-        syncBooleanAttrProp(fromEl, toEl, 'selected');
     },
     /**
      * The "value" attribute is special for the <input> element since it sets

--- a/test/browser/test.js
+++ b/test/browser/test.js
@@ -1332,6 +1332,18 @@ describe('morphdom' , function() {
         expect(el1.selectedIndex).to.equal(-1);
     });
 
+    it('should not clear selectedIndex when morphing option directly', function () {
+        var sel = node('select');
+        var el1 = node('option', {}, 'Option 1');
+        sel.appendChild(el1);
+        document.body.appendChild(sel);
+
+        var el2 = node('option', {}, 'Option 1');
+        var index = sel.selectedIndex;
+        morphdom(el1, el2);
+        expect(sel.selectedIndex).to.equal(index);
+    });
+
     it('can handle shadow DOM removal via shadowRoot', function () {
         var html = '<form><label>This should be removed</label><input type="checkbox" id="element-to-be-removed"><p>Element to keep in dom</p></form>';
         var container = document.createElement('div');


### PR DESCRIPTION
All tests have passed, not sure if there are any issues with non-Chrome browsers(eg. Edge) 🤔, any suggestions would be appreciated.