### PR TITLE
handle empty optgroups

### DIFF
--- a/src/specialElHandlers.js
+++ b/src/specialElHandlers.js
@@ -88,6 +88,11 @@ export default {
                 if (nodeName === 'OPTGROUP') {
                     optgroup = curChild;
                     curChild = optgroup.firstChild;
+                    // handle empty optgroups
+                    if (!curChild) {
+                        curChild = optgroup.nextSibling;
+                        optgroup = null;
+                    }
                 } else {
                     if (nodeName === 'OPTION') {
                         if (curChild.hasAttribute('selected')) {


### PR DESCRIPTION
Fixes https://github.com/phoenixframework/phoenix_live_view/issues/3742.

When a select contained an empty optgroup

```html
<select>
    <optgroup label="optgroupabove">
        <option selected value="1">a</option>
        <option value="2">b</option>
        <option value="3">c</option>
    </optgroup>
    <optgroup label="optgroupempty"></optgroup>
    <optgroup label="optgroupbelow">
        <option value="4">d</option>
        <option value="5">e</option>
        <option value="6">f</option>
    </optgroup>
</select>
```

morphdom would stop when encountering the empty optgroup, not patching the nodes below. This is fixed by skipping to the next sibling when an optgroup does not have any children.